### PR TITLE
Target .NET Core App 2.1

### DIFF
--- a/src/dotnet-warp/dotnet-warp.csproj
+++ b/src/dotnet-warp/dotnet-warp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <AssemblyName>dotnet-warp</AssemblyName>
 
         <Version>1.0.5</Version>

--- a/src/dotnet-warp/dotnet-warp.csproj
+++ b/src/dotnet-warp/dotnet-warp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
         <AssemblyName>dotnet-warp</AssemblyName>
 
         <Version>1.0.5</Version>


### PR DESCRIPTION
Because it can be done super easily and it seems wasteful to ask users to have .NET Core SDK 2.2 installed just for this tool if they don't have it. For example, doing this:

    docker run --rm -it microsoft/dotnet:2.1-sdk dotnet tool install -g dotnet-warp

gives the error:

```
error NU1202: Package dotnet-warp 1.0.5 is not compatible with netcoreapp2.1 (.NETCoreApp,Version=v2.1) / any. Package dotnet-warp 1.0.5 supports: netcoreapp2.2 (.NETCoreApp,Version=v2.2) / any
The tool package could not be restored.
Tool 'dotnet-warp' failed to install. This failure may have been caused by:

* You are attempting to install a preview release and did not use the --version option to specify the version.
* A package by this name was found, but it was not a .NET Core tool.
* The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
* You mistyped the name of the tool.
```

This PR fixes the situation by adding `netcoreapp2.1` as as _additional_ target.

I am not sure that the multi-targeting story is very widely understood or even documented for global tools. We could also just target `.netcoreapp2.1` (and .NET Core 2.1 has [LTS](https://dotnet.microsoft.com/platform/support/policy/dotnet-core)). I have tested that to work on 2.1 and 2.2. For example [dotnet-script](https://www.nuget.org/packages/dotnet-script/) does [target just 2.1](https://github.com/filipw/dotnet-script/blob/2170bb5f0eedfb6370d3ff80c1fcd7ff98676fc3/src/Dotnet.Script/Dotnet.Script.csproj#L7) and if you install it on 2.2:

    docker run --rm -it microsoft/dotnet:2.2-sdk dotnet tool install -g dotnet-script

it does so just fine:

```
Tools directory '/root/.dotnet/tools' is not currently on the PATH environment variable.
If you are using bash, you can add it to your profile by running the following command:

cat << \EOF >> ~/.bash_profile
# Add .NET Core SDK tools
export PATH="$PATH:/root/.dotnet/tools"
EOF

You can add it to the current session by running the following command:

export PATH="$PATH:/root/.dotnet/tools"

You can invoke the tool using the following command: dotnet-script
Tool 'dotnet-script' (version '0.28.0') was successfully installed.
```
