### PR TITLE
Support assemblies with dots in their name

### DIFF
--- a/src/dotnet-warp/CmdCommands/DotnetCli.cs
+++ b/src/dotnet-warp/CmdCommands/DotnetCli.cs
@@ -80,11 +80,10 @@ namespace DotnetWarp.CmdCommands
         
         private void UpdateContext(Context context)
         {
-            var depsFile = Directory.EnumerateFiles(context.TempPublishPath, "*.deps.json").Single();
-            
-            context.AssemblyName = Path.GetFileName(depsFile)
-                                       .Split(".")
-                                       .First();
+            const string depsJsonExtension = ".deps.json";
+            var depsJsonPath = Directory.EnumerateFiles(context.TempPublishPath, "*" + depsJsonExtension).Single();
+            var depsJsonFilename = Path.GetFileName(depsJsonPath);
+            context.AssemblyName = depsJsonFilename.Substring(0, depsJsonFilename.Length - depsJsonExtension.Length);
         }
     }
 }


### PR DESCRIPTION
Currently for `My.Project.deps.json`, will end up looking for `My.exe` instead of `My.Project.exe`.

I'm raising this from work where I can't easily test this, but can double check it all works as expected later on.