### PR TITLE
Add TargetFramework option 

### DIFF
--- a/src/dotnet-warp/ActionsBuilder.cs
+++ b/src/dotnet-warp/ActionsBuilder.cs
@@ -23,7 +23,7 @@ namespace DotnetWarp
             }
 
             actions.Add(ctx =>
-                dotnetCli.Publish(ctx, new DotnetPublishOptions(context.Rid, context.ShouldNotRootApplicationAssemblies, context.IsNoCrossGen)));
+                dotnetCli.Publish(ctx, new DotnetPublishOptions(context.Rid, context.ShouldNotRootApplicationAssemblies, context.IsNoCrossGen, context.TargetFramework)));
 
             actions.Add(ctx => warp.Pack(ctx, new WarpPackOptions(context.OutputPath)));
 

--- a/src/dotnet-warp/CmdCommands/DotnetCli.cs
+++ b/src/dotnet-warp/CmdCommands/DotnetCli.cs
@@ -35,6 +35,11 @@ namespace DotnetWarp.CmdCommands
                 $"-o {context.TempPublishPath.WithQuotes()}"
             };
 
+            if (string.IsNullOrWhiteSpace(dotnetPublishOptions.TargetFramework))
+            {
+                argumentList.Add($"-f {dotnetPublishOptions.TargetFramework}");    
+            }
+
             if (dotnetPublishOptions.IsNoRootApplicationAssemblies)
             {
                 argumentList.Add("/p:RootAllApplicationAssemblies=false");    

--- a/src/dotnet-warp/CmdCommands/Options/DotnetPublishOptions.cs
+++ b/src/dotnet-warp/CmdCommands/Options/DotnetPublishOptions.cs
@@ -2,15 +2,17 @@ namespace DotnetWarp.CmdCommands.Options
 {
     internal class DotnetPublishOptions
     {
-        public DotnetPublishOptions(string rid, bool isNoRootApplicationAssemblies, bool isNoCrossGen)
+        public DotnetPublishOptions(string rid, bool isNoRootApplicationAssemblies, bool isNoCrossGen, string targetFramework)
         {
             Rid = rid;
             IsNoRootApplicationAssemblies = isNoRootApplicationAssemblies;
             IsNoCrossGen = isNoCrossGen;
+            TargetFramework = targetFramework;
         }
 
         public string Rid { get; }
         public bool IsNoRootApplicationAssemblies { get; }
         public bool IsNoCrossGen { get; }
+        public string TargetFramework { get; }
     }
 }

--- a/src/dotnet-warp/Context.cs
+++ b/src/dotnet-warp/Context.cs
@@ -13,6 +13,7 @@ namespace DotnetWarp
             IEnumerable<string> msBuildProperties,
             LinkLevel link,
             bool isNoCrossGen,
+            string targetFramework,
             string outputPath)
         {
             Rid = rid;
@@ -28,6 +29,7 @@ namespace DotnetWarp
                 rid.StartsWith("osx") ? Platform.Value.MacOs : Platform.Value.Linux;
 
             TempPublishPath = Path.Combine(projectFileOrFolder, "dotnetwarp_temp");
+            TargetFramework = targetFramework;
         }
 
         public string AssemblyName { get; private set; }
@@ -42,6 +44,7 @@ namespace DotnetWarp
         public bool ShouldNotRootApplicationAssemblies => Link == LinkLevel.Aggressive;
         public string Rid { get; }
         public bool IsNoCrossGen { get; }
+        public string TargetFramework { get; }
         public string OutputPath { get; }
 
         public string OutputExeName => CurrentPlatform == Platform.Value.Windows

--- a/src/dotnet-warp/Program.cs
+++ b/src/dotnet-warp/Program.cs
@@ -39,12 +39,15 @@ namespace DotnetWarp
         [Option("-p|--property", Description =
             "Optional. Pass any additional MSBuild properties to 'dotnet publish' command." +
             "Example: -p:Version=2.0.1")]
-        
         public IEnumerable<string> MsBuildProperties { get; } = Enumerable.Empty<string>();
+
+        [Option("-f|--framework", Description =
+             "Publishes the application for the specified target framework. You must specify the target framework in the project file.")]
+        public string TargetFramework { get; }
 
         private Context BuildContext()
         {
-            var context = new Context(Rid, ProjectFileOrFolder, IsVerbose, MsBuildProperties, Link, IsNoCrossGen, Output);
+            var context = new Context(Rid, ProjectFileOrFolder, IsVerbose, MsBuildProperties, Link, IsNoCrossGen, TargetFramework, Output);
 
             return context;
         }


### PR DESCRIPTION
When there are several target frameworks in a project you need to specify the target framework for which you publish the app